### PR TITLE
feat: add GitHub Actions for automated deployments

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,0 +1,79 @@
+name: Deploy to Preview Environment
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    name: Deploy to Cloudflare Workers Preview
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          
+      - name: Install dependencies
+        run: npm ci
+        
+      - name: Build project
+        run: npm run build:cloudflare
+        
+      - name: Deploy to Preview
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          command: deploy --env preview
+          
+      - name: Comment PR with preview URL
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const accountId = '${{ secrets.CLOUDFLARE_ACCOUNT_ID }}';
+            const workerName = 'smaregi-mcp';
+            const prNumber = context.issue.number;
+            
+            // Construct preview URL (adjust pattern based on your Cloudflare setup)
+            const previewUrl = `https://preview.${workerName}.${accountId}.workers.dev`;
+            
+            const comment = `## 🚀 Preview Deployment Ready!
+            
+            Your changes have been deployed to the preview environment:
+            
+            🔗 **Preview URL**: ${previewUrl}
+            
+            ### Testing the deployment:
+            
+            1. Update your Claude Desktop config to use the preview URL:
+               \`\`\`json
+               {
+                 "mcpServers": {
+                   "smaregi-preview": {
+                     "url": "${previewUrl}/mcp",
+                     "transport": {
+                       "type": "http"
+                     }
+                   }
+                 }
+               }
+               \`\`\`
+            
+            2. Test the authentication flow and API calls
+            
+            ---
+            _This preview will be updated automatically when you push new commits._`;
+            
+            github.rest.issues.createComment({
+              issue_number: prNumber,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: comment
+            });

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,0 +1,63 @@
+name: Deploy to Production
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy-production:
+    runs-on: ubuntu-latest
+    name: Deploy to Cloudflare Workers Production
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          
+      - name: Install dependencies
+        run: npm ci
+        
+      - name: Build project
+        run: npm run build:cloudflare
+        
+      - name: Deploy to Production
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          command: deploy --env production
+          
+      - name: Create deployment notification
+        uses: actions/github-script@v7
+        if: success()
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const accountId = '${{ secrets.CLOUDFLARE_ACCOUNT_ID }}';
+            const workerName = 'smaregi-mcp';
+            const productionUrl = `https://${workerName}.${accountId}.workers.dev`;
+            
+            // Get the commit message
+            const commit = context.payload.head_commit;
+            const commitMessage = commit.message;
+            const commitUrl = commit.url;
+            const author = commit.author.name;
+            
+            console.log(`✅ Production deployment successful!
+            
+            URL: ${productionUrl}
+            Commit: ${commitMessage}
+            Author: ${author}
+            Link: ${commitUrl}`);
+            
+      - name: Notify deployment failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            core.setFailed('Production deployment failed. Please check the logs.');

--- a/README.md
+++ b/README.md
@@ -181,6 +181,15 @@ wrangler secret put CLIENT_SECRET --env production
 }
 ```
 
+#### 自動デプロイ（GitHub Actions）
+
+このプロジェクトはGitHub Actionsによる自動デプロイに対応しています：
+
+- **Pull Request作成/更新時** → プレビュー環境に自動デプロイ
+- **mainブランチへのマージ時** → 本番環境に自動デプロイ
+
+詳細な設定方法は[GitHub Actions セットアップガイド](docs/github-actions-setup.md)を参照してください。
+
 ### 使用方法
 
 #### Node.js版

--- a/docs/github-actions-setup.md
+++ b/docs/github-actions-setup.md
@@ -1,0 +1,154 @@
+# GitHub Actions 自動デプロイセットアップガイド
+
+このガイドでは、GitHub Actionsを使用してCloudflare Workersへの自動デプロイを設定する方法を説明します。
+
+## 概要
+
+- **PRを作成/更新** → プレビュー環境に自動デプロイ
+- **mainブランチにマージ** → 本番環境に自動デプロイ
+
+## 前提条件
+
+- Cloudflareアカウント
+- GitHub リポジトリの管理者権限
+- Wranglerで事前にKVネームスペースを作成済み
+
+## セットアップ手順
+
+### 1. Cloudflare APIトークンの作成
+
+1. [Cloudflareダッシュボード](https://dash.cloudflare.com/)にログイン
+2. 右上のプロフィールアイコン → **My Profile** → **API Tokens**
+3. **Create Token** をクリック
+4. **Custom token** を選択して以下の権限を設定：
+
+   **Account permissions:**
+   - Account:Cloudflare Workers Scripts:Edit
+   - Account:Workers KV Storage:Edit
+   
+   **Zone permissions:**
+   - Zone:Workers Routes:Edit (必要な場合)
+
+5. **Continue to summary** → **Create Token**
+6. 表示されたトークンをコピー（この画面を離れると二度と表示されません）
+
+### 2. Cloudflare Account IDの取得
+
+1. Cloudflareダッシュボードの右サイドバーから **Account ID** をコピー
+
+### 3. GitHub Secretsの設定
+
+GitHubリポジトリで以下のシークレットを設定：
+
+1. リポジトリの **Settings** → **Secrets and variables** → **Actions**
+2. **New repository secret** をクリックして以下を追加：
+
+| Secret Name | Value | 説明 |
+|------------|-------|-----|
+| `CLOUDFLARE_API_TOKEN` | 手順1で作成したトークン | Cloudflare APIアクセス用 |
+| `CLOUDFLARE_ACCOUNT_ID` | 手順2で取得したAccount ID | アカウント識別用 |
+
+### 4. Cloudflareシークレットの設定
+
+環境ごとにOAuthクライアントの認証情報を設定：
+
+#### プレビュー環境
+```bash
+# CLIENT_IDとCLIENT_SECRETを設定
+wrangler secret put CLIENT_ID --env preview
+wrangler secret put CLIENT_SECRET --env preview
+```
+
+#### 本番環境
+```bash
+# CLIENT_IDとCLIENT_SECRETを設定
+wrangler secret put CLIENT_ID --env production
+wrangler secret put CLIENT_SECRET --env production
+```
+
+### 5. wrangler.tomlの確認
+
+以下の環境設定が正しく記載されていることを確認：
+
+```toml
+[env.preview]
+# プレビュー環境の設定
+kv_namespaces = [
+  { binding = "SESSIONS", id = "YOUR_PREVIEW_SESSIONS_ID" },
+  { binding = "TOKENS", id = "YOUR_PREVIEW_TOKENS_ID" }
+]
+
+[env.production]
+# 本番環境の設定
+kv_namespaces = [
+  { binding = "SESSIONS", id = "YOUR_PRODUCTION_SESSIONS_ID" },
+  { binding = "TOKENS", id = "YOUR_PRODUCTION_TOKENS_ID" }
+]
+```
+
+## 使用方法
+
+### プレビュー環境へのデプロイ
+
+1. 新しいブランチを作成してPRを開く
+2. GitHub Actionsが自動的に実行される
+3. デプロイが完了すると、PRにプレビューURLがコメントされる
+4. コメントに記載されたURLでテスト可能
+
+### 本番環境へのデプロイ
+
+1. PRをmainブランチにマージ
+2. GitHub Actionsが自動的に本番環境にデプロイ
+3. Actions タブでデプロイ状況を確認可能
+
+## デプロイURLの形式
+
+### プレビュー環境
+```
+https://preview.smaregi-mcp.<account-id>.workers.dev
+```
+
+### 本番環境
+```
+https://smaregi-mcp.<account-id>.workers.dev
+```
+
+カスタムドメインを使用している場合は、それぞれの環境に応じたURLになります。
+
+## トラブルシューティング
+
+### デプロイが失敗する場合
+
+1. **GitHub Actions のログを確認**
+   - リポジトリの **Actions** タブでワークフローの詳細を確認
+
+2. **シークレットの確認**
+   ```bash
+   # 設定されているシークレットの一覧を確認
+   wrangler secret list --env preview
+   wrangler secret list --env production
+   ```
+
+3. **KVネームスペースの確認**
+   ```bash
+   # KVネームスペースが存在するか確認
+   wrangler kv:namespace list
+   ```
+
+### よくある問題
+
+- **Authentication error**: `CLOUDFLARE_API_TOKEN`が正しく設定されているか確認
+- **KV namespace not found**: wrangler.tomlのKV IDが正しいか確認
+- **Script not found**: ワーカー名がwrangler.tomlと一致しているか確認
+
+## セキュリティに関する注意
+
+1. APIトークンは最小限の権限で作成する
+2. 本番環境と開発環境で異なるOAuthクライアントを使用する
+3. シークレットは絶対にコードにハードコードしない
+4. APIトークンは定期的にローテーションする
+
+## 関連ドキュメント
+
+- [Cloudflare Workers デプロイメントガイド](./cloudflare-deployment.md)
+- [Wrangler Action ドキュメント](https://github.com/cloudflare/wrangler-action)

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -53,6 +53,18 @@ kv_namespaces = [
   { binding = "SESSIONS", id = "PRODUCTION_SESSIONS_ID" },
   { binding = "TOKENS", id = "PRODUCTION_TOKENS_ID" }
 ]
+# 本番環境用の変数
+[env.production.vars]
+DEBUG = "false"
+SERVER_NAME = "smaregi"
+SERVER_VERSION = "1.0.0"
+# 本番環境用のリダイレクトURI（実際のURLに置き換えてください）
+REDIRECT_URI = "https://smaregi-mcp.youraccount.workers.dev/auth/callback"
+SMAREGI_AUTH_URL = "https://id.smaregi.dev/authorize"
+SMAREGI_TOKEN_ENDPOINT = "https://id.smaregi.dev/authorize/token"
+SMAREGI_USERINFO_ENDPOINT = "https://id.smaregi.dev/userinfo"
+SMAREGI_API_URL = "https://api.smaregi.dev"
+NODE_ENV = "production"
 # シークレットはワーカー管理画面やCLIから設定する
 # wrangler secret put CLIENT_ID --env production
 # wrangler secret put CLIENT_SECRET --env production


### PR DESCRIPTION
## 概要

GitHub Actionsを使用して、Cloudflare Workersへの自動デプロイを実装しました。

## 主な変更内容

### 🚀 自動デプロイワークフロー

1. **プレビュー環境デプロイ** (`.github/workflows/deploy-preview.yml`)
   - Pull Request作成/更新時に自動実行
   - プレビュー環境へデプロイ
   - PRにプレビューURLをコメント

2. **本番環境デプロイ** (`.github/workflows/deploy-production.yml`)
   - mainブランチへのマージ時に自動実行
   - 本番環境へデプロイ
   - デプロイ成功/失敗を通知

### 📚 ドキュメント

- **GitHub Actions セットアップガイド** (`docs/github-actions-setup.md`)
  - Cloudflare APIトークンの作成方法
  - GitHub Secretsの設定方法
  - トラブルシューティング

### 🔧 設定更新

- **wrangler.toml**
  - 本番環境用の環境変数を追加
  - 環境別の設定を整理

## セットアップ手順

### 1. GitHub Secretsの設定

以下のシークレットをリポジトリに設定してください：

- `CLOUDFLARE_API_TOKEN`: Cloudflare APIトークン
- `CLOUDFLARE_ACCOUNT_ID`: CloudflareアカウントID

### 2. Cloudflareシークレットの設定

```bash
# プレビュー環境
wrangler secret put CLIENT_ID --env preview
wrangler secret put CLIENT_SECRET --env preview

# 本番環境
wrangler secret put CLIENT_ID --env production
wrangler secret put CLIENT_SECRET --env production
```

## 動作確認

1. このPRがマージされると、プレビュー環境へ自動デプロイされます
2. PRにコメントされるプレビューURLで動作確認できます
3. マージ後は本番環境へ自動デプロイされます

## 注意事項

- 初回セットアップ時は、KVネームスペースのIDを環境に合わせて更新してください
- APIトークンは最小限の権限で作成することを推奨します

🤖 Generated with [Claude Code](https://claude.ai/code)